### PR TITLE
Added 2.66 compatibility.

### DIFF
--- a/spritify.py
+++ b/spritify.py
@@ -40,7 +40,7 @@ class SpriteSheetProperties(bpy.types.PropertyGroup):
         name = "Sprite Sheet Filepath",
         description = "Save location for sprite sheet (should be PNG format)",
         subtype = 'FILE_PATH',
-        default = bpy.context.scene.render.filepath + "sprites.png")
+        default = os.path.join(bpy.context.user_preferences.filepaths.render_output_directory, "sprites.png"))
     quality = bpy.props.IntProperty(
         name = "Quality",
         description = "Quality setting for sprite sheet image",


### PR DESCRIPTION
The default output path is now found from the user preferences
instead of the scene render path.  This was added because Blender
2.66 restricts access to bpy.context while registering and
unregistering modules as noted in http://wiki.blender.org/
index.php/Dev:Ref/Release_Notes/2.66/Addons#Restricted_Context.
