### PR TITLE
fixes a problem with the order returned by os.walk

### DIFF
--- a/spritify.py
+++ b/spritify.py
@@ -121,7 +121,7 @@ def spritify(scene):
 		# Preload images
 		images = []
 		for dirname, dirnames, filenames in os.walk(bpy.path.abspath(scene.render.filepath)):
-			for filename in filenames:
+			for filename in sorted(filenames):
 				images.append(os.path.join(dirname, filename))
 		
 		# Calc number of images per file


### PR DESCRIPTION
On linux the sprites were being combined out of order; not respecting an "alphabetical" order by filename. Sorting the list of filenames fixes it.