### PR TITLE
force ImageMagick / Montage output to be 8 bit

### DIFF
--- a/spritify.py
+++ b/spritify.py
@@ -138,6 +138,7 @@ def spritify(scene):
 			
 			montage_call = [
 				"montage",
+				"-depth", "8",
 				"-tile", tile_setting,
 				"-geometry", str(scene.render.resolution_x) + "x" + str(scene.render.resolution_y) \
 					+ "+" + str(scene.spritesheet.offset_x) + "+" + str(scene.spritesheet.offset_y),


### PR DESCRIPTION
apparently Factorio fails to load the spritesheet otherwise.. this one may have to do with the individual OS and ImageMagick installation