### PR TITLE
Fix linux paths and show error and success messages.

### DIFF
--- a/spritify.py
+++ b/spritify.py
@@ -19,7 +19,11 @@ Convert rendered frames into a sprite sheet once render is complete.
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # ***** END GPL LICENCE BLOCK *****
-
+import bpy
+import os
+import subprocess
+import math
+from bpy.app.handlers import persistent
 
 bl_info = {
     "name": "Spritify",
@@ -27,86 +31,103 @@ bl_info = {
     "version": (0, 6, 4),
     "blender": (2, 80, 0),
     "location": "Render > Spritify",
-    "description": "Converts rendered frames into a sprite sheet once render is complete",
+    "description": ("Converts rendered frames into a sprite sheet"
+                    " once render is complete"),
     "warning": "Requires ImageMagick",
-    "wiki_url": "http://wiki.blender.org/index.php?title=Extensions:2.6/Py/Scripts/Render/Spritify",
+    "wiki_url": ("http://wiki.blender.org/index.php"
+                 "?title=Extensions:2.6/Py/Scripts/Render/Spritify"),
     "tracker_url": "https://github.com/FreezingMoon/Spritify/issues",
-    "category": "Render"}
-
-
-import bpy, os, subprocess, math
-from bpy.app.handlers import persistent
+    "category": "Render",
+}
 
 
 class SpriteSheetProperties(bpy.types.PropertyGroup):
     filepath: bpy.props.StringProperty(
-        name = "Sprite Sheet Filepath",
-        description = "Save location for sprite sheet (should be PNG format)",
-        subtype = 'FILE_PATH',
-        default = os.path.join(bpy.context.preferences.filepaths.render_output_directory, "sprites.png"))
+        name="Sprite Sheet Filepath",
+        description="Save location for sprite sheet (should be PNG format)",
+        subtype='FILE_PATH',
+        default=os.path.join(
+            bpy.context.preferences.filepaths.render_output_directory,
+            "sprites.png"
+        ),
+    )
     imagemagick_path: bpy.props.StringProperty(
-        name = "Imagemagick Path",
-        description = "Path where the Imagemagick binaries can be found (only on Linux and macOS)",
-        subtype = 'FILE_PATH',
-        default = '/usr/bin'
+        name="Imagemagick Path",
+        description=("Path where the Imagemagick binaries can be found"
+                     " (only on Linux and macOS)"),
+        subtype='FILE_PATH',
+        default='/usr/bin',
     )
     quality: bpy.props.IntProperty(
-        name = "Quality",
-        description = "Quality setting for sprite sheet image",
-        subtype = 'PERCENTAGE',
-        max = 100,
-        default = 100)
+        name="Quality",
+        description="Quality setting for sprite sheet image",
+        subtype='PERCENTAGE',
+        max=100,
+        default=100,
+    )
     is_rows: bpy.props.EnumProperty(
-        name = "Rows/Columns",
-        description = "Choose if tiles will be arranged by rows or columns",
-        items = (('ROWS', "Rows", "Rows"), ('COLUMNS', "Columns", "Columns")),
-        default = 'ROWS')
+        name="Rows/Columns",
+        description="Choose if tiles will be arranged by rows or columns",
+        items=(('ROWS', "Rows", "Rows"), ('COLUMNS', "Columns", "Columns")),
+        default='ROWS',
+    )
     tiles: bpy.props.IntProperty(
-        name = "Tiles",
-        description = "Number of tiles in the chosen direction (rows or columns)",
-        default = 8)
-    files : bpy.props.IntProperty(
-        name = "File count",
-        description = "Number of files to split sheet into",
-        default = 1)
+        name="Tiles",
+        description="Number of tiles in the chosen direction (rows or columns)",
+        default=8,
+    )
+    files: bpy.props.IntProperty(
+        name="File count",
+        description="Number of files to split sheet into",
+        default=1,
+    )
     offset_x: bpy.props.IntProperty(
-        name = "Offset X",
-        description = "Horizontal offset between tiles (in pixels)",
-        default = 2)
+        name="Offset X",
+        description="Horizontal offset between tiles (in pixels)",
+        default=2,
+    )
     offset_y: bpy.props.IntProperty(
-        name = "Offset Y",
-        description = "Vertical offset between tiles (in pixels)",
-        default = 2)
+        name="Offset Y",
+        description="Vertical offset between tiles (in pixels)",
+        default=2,
+    )
     bg_color: bpy.props.FloatVectorProperty(
-        name = "Background Color",
-        description = "Fill color for sprite backgrounds",
-        subtype = 'COLOR',
-        size = 4,
-        min = 0.0,
-        max = 1.0,
-        default = (0.0, 0.0, 0.0, 0.0))
+        name="Background Color",
+        description="Fill color for sprite backgrounds",
+        subtype='COLOR',
+        size=4,
+        min=0.0,
+        max=1.0,
+        default=(0.0, 0.0, 0.0, 0.0),
+    )
     auto_sprite: bpy.props.BoolProperty(
-        name = "AutoSpritify",
-        description = "Automatically create a spritesheet when rendering is complete",
-        default = True)
+        name="AutoSpritify",
+        description=("Automatically create a spritesheet"
+                     " when rendering is complete"),
+        default=True,
+    )
     auto_gif: bpy.props.BoolProperty(
-        name = "AutoGIF",
-        description = "Automatically create an animated GIF when rendering is complete",
-        default = True)
+        name="AutoGIF",
+        description=("Automatically create an animated GIF"
+                     " when rendering is complete"),
+        default=True,
+    )
     support_multiview: bpy.props.BoolProperty(
-        name = "Support Multiviews",
-        description = "Render multiple spritesheets based on multivie suffixes if stereoscopy/multiview is configured",
-        default = True)
+        name="Support Multiviews",
+        description=("Render multiple spritesheets based on multiview"
+                     " suffixes if stereoscopy/multiview is configured"),
+        default=True,
+    )
 
 
 def find_bin_path_windows():
     import winreg
 
-    REG_PATH = "SOFTWARE\ImageMagick\Current"
+    REG_PATH = "SOFTWARE\\ImageMagick\\Current"
 
     try:
         registry_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, REG_PATH, 0,
-                                       winreg.KEY_READ)
+                                      winreg.KEY_READ)
         value, regtype = winreg.QueryValueEx(registry_key, "BinPath")
         winreg.CloseKey(registry_key)
 
@@ -119,7 +140,7 @@ def find_bin_path_windows():
 
 @persistent
 def spritify(scene):
-    if scene.spritesheet.auto_sprite == True:
+    if scene.spritesheet.auto_sprite:
         print("Making sprite sheet")
         # Remove existing spritesheet if it's already there
         if os.path.exists(bpy.path.abspath(scene.spritesheet.filepath)):
@@ -132,7 +153,8 @@ def spritify(scene):
 
         suffixes = []
 
-        if scene.spritesheet.support_multiview and scene.render.use_multiview and scene.render.views_format == 'MULTIVIEW':
+        if (scene.spritesheet.support_multiview and scene.render.use_multiview
+                and scene.render.views_format == 'MULTIVIEW'):
             for view in scene.render.views:
                 suffixes.append(view.file_suffix)
         else:
@@ -161,67 +183,85 @@ def spritify(scene):
                     '\n2. Render, Render Animation.'
                     ''.format(render_dir)
                 )
-            #While is faster than for+range
+            # While is faster than for+range
             while offset < len(images):
                 current_images = images[offset:offset+per_file]
                 filename = scene.spritesheet.filepath
                 if scene.spritesheet.files > 1:
-                    filename = "%s-%d-%s%s" % (scene.spritesheet.filepath[:-4], index, suffix, scene.spritesheet.filepath[-4:])
+                    filename = "%s-%d-%s%s" % (scene.spritesheet.filepath[:-4],
+                                               index, suffix,
+                                               scene.spritesheet.filepath[-4:])
                 else:
-                    filename = "%s%s%s" % (scene.spritesheet.filepath[:-4], suffix, scene.spritesheet.filepath[-4:])
+                    filename = "%s%s%s" % (scene.spritesheet.filepath[:-4],
+                                           suffix,
+                                           scene.spritesheet.filepath[-4:])
 
                 bin_path = scene.spritesheet.imagemagick_path
 
                 if os.name == "nt":
                     bin_path = find_bin_path_windows()
 
-                montage_path = "%s/montage" % bin_path
-                if not os.path.isfile(montage_path):
-                    raise FileNotFoundError(
-                        'The executable "{}" does not exist.'
-                        ' Ensure ImageMagick is installed and that the bin directory is correct in Render Options, Spritify.'
-                        ''.format(montage_path)
-                    )
-                width = scene.render.resolution_x * scene.render.resolution_percentage / 100
-                height = scene.render.resolution_y * scene.render.resolution_percentage / 100
+                width = (scene.render.resolution_x
+                         * scene.render.resolution_percentage / 100)
+                height = (scene.render.resolution_y
+                          * scene.render.resolution_percentage / 100)
 
                 if scene.render.use_crop_to_border:
-                    width = scene.render.border_max_x * width - scene.render.border_min_x * width
-                    height = scene.render.border_max_y * height - scene.render.border_min_y * height
+                    width = (scene.render.border_max_x
+                             * width - scene.render.border_min_x * width)
+                    height = (scene.render.border_max_y
+                              * height - scene.render.border_min_y * height)
+                background = (
+                    "rgba({},{},{},{})".format(
+                        str(scene.spritesheet.bg_color[0] * 100),
+                        str(scene.spritesheet.bg_color[1] * 100),
+                        str(scene.spritesheet.bg_color[2] * 100),
+                        str(scene.spritesheet.bg_color[3] * 100),
+                    )
+                )
+                geometry = "{}x{}+{}+{}".format(
+                    width,
+                    height,
+                    scene.spritesheet.offset_x,
+                    scene.spritesheet.offset_y
+                )
 
+                depth = "8"
                 montage_call = [
-                    montage_path,
-                    "-depth", "8",
-                    "-tile", tile_setting,
-                    "-geometry", str(width) + "x" + str(height) \
-                        + "+" + str(scene.spritesheet.offset_x) + "+" + str(scene.spritesheet.offset_y),
-                    "-background", "rgba(" + \
-                        str(scene.spritesheet.bg_color[0] * 100) + "%, " + \
-                        str(scene.spritesheet.bg_color[1] * 100) + "%, " + \
-                        str(scene.spritesheet.bg_color[2] * 100) + "%, " + \
-                        str(scene.spritesheet.bg_color[3]) + ")",
-                    "-quality", str(scene.spritesheet.quality)
+                    "{}/montage".format(bin_path),
+                    "-depth",
+                    depth,
+                    "-tile",
+                    tile_setting,
+                    "-geometry",
+                    geometry,
+                    "-background",
+                    background,
+                    "-quality{}".format(scene.spritesheet.quality),
                 ]
                 montage_call.extend(current_images)
                 montage_call.append(bpy.path.abspath(filename))
 
                 result = subprocess.call(montage_call)
-                print(montage_call, "result:", result)
+                # print(montage_call, "result:", result)
+                # ^ still 1 even if succeeds for some reason
                 offset += per_file
                 index += 1
 
 
 @persistent
 def gifify(scene):
-    if scene.spritesheet.auto_gif == True:
+    if scene.spritesheet.auto_gif:
         print("Generating animated GIF")
-        # Remove existing animated GIF if it's already there (uses the same path as the spritesheet)
-        if os.path.exists(bpy.path.abspath(scene.spritesheet.filepath[:-3] + "gif")):
+        # Remove existing animated GIF if it's already there
+        #   (uses the same path as the spritesheet)
+        if os.path.exists(
+                bpy.path.abspath(scene.spritesheet.filepath[:-3] + "gif")
+                ):
             os.remove(bpy.path.abspath(scene.spritesheet.filepath[:-3] + "gif"))
 
         # If windows, try and find binary
         convert_path = "%s/convert" % scene.spritesheet.imagemagick_path
-
 
         if os.name == "nt":
             bin_path = find_bin_path_windows()
@@ -232,7 +272,8 @@ def gifify(scene):
         if not os.path.isfile(convert_path):
             raise FileNotFoundError(
                 'The executable "{}" does not exist.'
-                ' Ensure ImageMagick is installed and that the bin directory is correct in Render Options, Spritify.'
+                ' Ensure ImageMagick is installed and that'
+                ' the bin directory is correct in Render Options, Spritify.'
                 ''.format(convert_path)
             )
 
@@ -251,13 +292,19 @@ def gifify(scene):
             "-delay", "1x" + str(scene.render.fps),
             "-dispose", "background",
             "-loop", "0",
-            bpy.path.abspath(scene.render.filepath) + "*", #XXX Assumes the files in the render path are only for the rendered animation
-            bpy.path.abspath(scene.spritesheet.filepath[:-3] + "gif")])
+            bpy.path.abspath(scene.render.filepath) + "*",
+            # FIXME: ^ scene.render.filepath assumes the files in the
+            #   render path are only for the rendered animation
+            bpy.path.abspath(scene.spritesheet.filepath[:-3] + "gif")
+        ])
 
 
-# Operator (just wrapping the handler to make things easy if auto_sprite is False)
 class SpritifyOperator(bpy.types.Operator):
-    """Generate a sprite sheet from completed animation render"""
+    """
+    Generate a sprite sheet from completed animation render
+    (This operator just wraps the handler to make things easy if
+    auto_sprite is False).
+    """
     bl_idname = "render.spritify"
     bl_label = "Generate a sprite sheet from a completed animation render"
 
@@ -274,7 +321,9 @@ class SpritifyOperator(bpy.types.Operator):
         if context.scene is not None:
             if not os.path.isdir(tmp_path):
                 return True  # FIXME: See comment in next line.
-        if (context.scene is not None) and len(os.listdir(tmp_path)) > 0:  # FIXME: a bit hacky; an empty dir doesn't necessarily mean that the render has been done
+        if (context.scene is not None) and len(os.listdir(tmp_path)) > 0:
+            # FIXME: a bit hacky; an empty dir doesn't necessarily mean
+            #   that the render has been done
             return True
         else:
             return False
@@ -282,18 +331,20 @@ class SpritifyOperator(bpy.types.Operator):
 
     def execute(self, context):
         toggle = False
-        if context.scene.spritesheet.auto_sprite == False:
+        if not context.scene.spritesheet.auto_sprite:
             context.scene.spritesheet.auto_sprite = True
             toggle = True
         spritify(context.scene)
-        if toggle == True:
+        if toggle:
             context.scene.spritesheet.auto_sprite = False
         return {'FINISHED'}
 
 
-# Operator (just wraps the handler if auto_gif is False)
 class GIFifyOperator(bpy.types.Operator):
-    """Generate an animated GIF from completed animation render"""
+    """
+    Generate an animated GIF from completed animation render
+    (This Operator just wraps the handler if auto_gif is False).
+    """
     bl_idname = "render.gifify"
     bl_label = "Generate an animated GIF from a completed animation render"
 
@@ -310,7 +361,9 @@ class GIFifyOperator(bpy.types.Operator):
         if context.scene is not None:
             if not os.path.isdir(tmp_path):
                 return True  # FIXME: See comment in next line.
-        if (context.scene is not None) and len(os.listdir(tmp_path)) > 0:  # FIXME: a bit hacky; an empty dir doesn't necessarily mean that the render has been done
+        if ((context.scene is not None) and (len(os.listdir(tmp_path)) > 0)):
+            # FIXME: a bit hacky; an empty dir doesn't necessarily mean
+            #   that the render has been done
             return True
         else:
             return False
@@ -318,16 +371,14 @@ class GIFifyOperator(bpy.types.Operator):
 
     def execute(self, context):
         toggle = False
-        if context.scene.spritesheet.auto_gif == False:
+        if not context.scene.spritesheet.auto_gif:
             context.scene.spritesheet.auto_gif = True
             toggle = True
         gifify(context.scene)
-        if toggle == True:
+        if toggle:
             context.scene.spritesheet.auto_gif = False
         return {'FINISHED'}
 
-
-# UI
 
 class SpritifyPanel(bpy.types.Panel):
     """UI Panel for Spritify"""
@@ -343,42 +394,45 @@ class SpritifyPanel(bpy.types.Panel):
         layout.prop(context.scene.spritesheet, "imagemagick_path")
         layout.prop(context.scene.spritesheet, "filepath")
         box = layout.box()
-        split = box.split(factor = 0.5)
+        split = box.split(factor=0.5)
         col = split.column()
-        col.operator("render.spritify", text = "Generate Sprite Sheet")
+        col.operator("render.spritify", text="Generate Sprite Sheet")
         col = split.column()
         col.prop(context.scene.spritesheet, "auto_sprite")
-        split = box.split(factor = 0.5)
-        col = split.column(align = True)
-        col.row().prop(context.scene.spritesheet, "is_rows", expand = True)
+        split = box.split(factor=0.5)
+        col = split.column(align=True)
+        col.row().prop(context.scene.spritesheet, "is_rows", expand=True)
         col.prop(context.scene.spritesheet, "tiles")
-        sub = col.split(factor = 0.5)
+        sub = col.split(factor=0.5)
         sub.prop(context.scene.spritesheet, "offset_x")
         sub.prop(context.scene.spritesheet, "offset_y")
         col = split.column()
         col.prop(context.scene.spritesheet, "bg_color")
-        col.prop(context.scene.spritesheet, "quality", slider = True)
+        col.prop(context.scene.spritesheet, "quality", slider=True)
         box.prop(context.scene.spritesheet, "support_multiview")
         box = layout.box()
-        split = box.split(factor = 0.5)
+        split = box.split(factor=0.5)
         col = split.column()
-        col.operator("render.gifify", text = "Generate Animated GIF")
+        col.operator("render.gifify", text="Generate Animated GIF")
         col = split.column()
         col.prop(context.scene.spritesheet, "auto_gif")
         box.label(text="Animated GIF uses the spritesheet filepath")
 
 
-
-# Registration
-
 def register():
+    '''
+    Register the add-on.
+    '''
     bpy.utils.register_class(SpriteSheetProperties)
-    bpy.types.Scene.spritesheet = bpy.props.PointerProperty(type = SpriteSheetProperties)
+    bpy.types.Scene.spritesheet = bpy.props.PointerProperty(
+        type=SpriteSheetProperties
+    )
     bpy.app.handlers.render_complete.append(spritify)
     bpy.app.handlers.render_complete.append(gifify)
     bpy.utils.register_class(SpritifyOperator)
     bpy.utils.register_class(GIFifyOperator)
     bpy.utils.register_class(SpritifyPanel)
+
 
 def unregister():
     bpy.utils.unregister_class(SpritifyPanel)
@@ -388,6 +442,7 @@ def unregister():
     bpy.app.handlers.render_complete.remove(gifify)
     del bpy.types.Scene.spritesheet
     bpy.utils.unregister_class(SpriteSheetProperties)
+
 
 if __name__ == '__main__':
     register()


### PR DESCRIPTION
- [x] Resolves #20.
- [x] Use PEP8 more (Geany lint set to `python3 -m pycodestyle --max-line-length=80 "%f"`).
- [x] Show a message whether the operation succeeds or fails.
  - [x] Don't hide exceptions.
    - [x] Check if the executable actually exists. If not, instead of trying to run and failing (potentially silently), raise an exception with a meaningful message explaining that the ImageMagick is missing or the bin path is incorrect (Exceptions appear in a GUI popup automatically in Blender).
  - [x] Check whether the file was really created or not (To make sure in the case of gif export, erase the destination if it already exists. How to do this in sprite sheet mode is unclear since it seems to keep using the same image so knowing the filename ahead of time would be necessary).

This is code is tested and working on Blender 3.3.1 (generated sprite sheet and gif).